### PR TITLE
Added primitive support for high DPI displays

### DIFF
--- a/resources/app/index.js
+++ b/resources/app/index.js
@@ -6,7 +6,17 @@ document.addEventListener('DOMContentLoaded', function () {
     plugins.load(context, function (err, loaded) {
         if(err) return console.error(err)
         console.log('Plugins loaded successfully.')
-    })
+    });
+
+    var electronScreen = require('screen');
+    var webFrame = require('web-frame');
+    var size = electronScreen.getPrimaryDisplay().workAreaSize;
+
+    function log2(number) {
+        return Math.log(number) / Math.log(2);
+    }
+
+    webFrame.setZoomFactor(Math.floor(log2((size.width*size.height)/(800*600))));
 })
 
 ipc.on('update-available', function () {


### PR DESCRIPTION
Since high DPI support in chromium/atom/electron is still questionable, I've implemented a workaround based upon...

this issue: https://github.com/atom/electron/issues/615 
and this comment on said issue: https://github.com/atom/electron/issues/615#issuecomment-116366096

This shouldn't affect non-high-DPI displays however **I was unable to test this on a non-high-DPI display so please verify I didn't break anything before merging this pull request**.

Eventually when support for high-DPI is improved in chromium/atom this should be re-worked or removed completely depending on their implementation.
